### PR TITLE
Disable DiffsingerPack for mac by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
       run: 7z x -o"./bin/${{ matrix.os.arch }}/Vocoders/rhythmizer_zh_opencpop_strict" ./rhythmizer_zh_opencpop_strict.dsvocoder
      
     - name: compress x64 DiffsingerPack
+      if: ${{ matrix.os.arch == 'win-x64' }}
       run: 7z a OpenUtau-${{ matrix.os.arch }}-${{ inputs.version }}-DiffsingerPack.zip ./bin/${{ matrix.os.arch }}/*
      
     - name: Upload artifact x64
@@ -81,16 +82,24 @@ jobs:
         path: OpenUtau-${{ matrix.os.arch }}-${{ inputs.version }}.zip
         
     - name: Upload artifact x64 DiffsingerPack
+      if: ${{ matrix.os.arch == 'win-x64' }}
       uses: actions/upload-artifact@v1.0.0
       with:
         name: OpenUtau-${{ matrix.os.arch }}-${{ inputs.version }}-DiffsingerPack.zip
         path: OpenUtau-${{ matrix.os.arch }}-${{ inputs.version }}-DiffsingerPack.zip
 
-    - name: Create release
+    - name: Create release and upload artifact
       if: ${{ inputs.create-release }}
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ inputs.version }}
         files: |
           OpenUtau-${{ matrix.os.arch }}-${{ inputs.version }}.zip
+    
+    - name: Create release and upload artifact DiffsingerPack
+      if: ${{ inputs.create-release && matrix.os.arch == 'win-x64' }}
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ inputs.version }}
+        files: |
           OpenUtau-${{ matrix.os.arch }}-${{ inputs.version }}-DiffsingerPack.zip


### PR DESCRIPTION
默认关闭 MacOS 的 DiffsingerPack 支持, 因为 MacOS 的默认数据目录不是当前文件夹.
Disable Mac's DiffSingerPack support, as the default data folder in MacOS is /Users/xxx/Library/OpenUTAU instead of the root directory.

注意: GitHub CI 生成的文件是没有签名的, 运行前需要执行以下命令来允许未签名软件:
Note: Files generated by GitHub CI are not signed by default, you need to run the following command to allow unsigned software.
```bash
sudo spctl --master-disable
```

该 CI 目前工作正常, 见:  
https://github.com/fishaudio/OpenUtau/actions/runs/4288870620. 
https://github.com/fishaudio/OpenUtau/releases/tag/0.1.36.11
